### PR TITLE
fix: correctly handle uuid when there is no trx uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [2.2.2] - 2026-06-16
+
 - fix: correctly handle uuid when there is no trx uuid
 
 ### [2.2.1] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix: correctly handle uuid when there is no trx uuid
+
 ### [2.2.1] - 2026-06-12
 
 - fix: paint the queue cell yellow on a deferral (denysoft)

--- a/index.js
+++ b/index.js
@@ -155,9 +155,7 @@ exports.w_deny = function (next, connection, params) {
   // a deny colors the offending plugin's cell; it does not end the
   // connection, so leave local_port lit until the disconnect result arrives
   const req = {
-    uuid: connection.transaction
-      ? connection.transaction.uuid
-      : connection.uuid,
+    uuid: connection.transaction?.uuid ?? connection.uuid,
     remote_host: display.get_remote_host(connection),
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-watch",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Watch live SMTP traffic in a web interface",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Fixes:

```
[CRIT] [E1FB6536-89D5-47F9-A4A1-692F14E8F8D0.1.1] [outbound] Plugin watch failed: TypeError: Cannot read properties of undefined (reading 'replace')
```