### PR TITLE
fix: correctly handle case where there is no uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [2.2.3] - 2026-06-16
+
+- fix: correctly handle case where there is no uuid
+
 ### [2.2.2] - 2026-06-16
 
 - fix: correctly handle uuid when there is no trx uuid

--- a/index.js
+++ b/index.js
@@ -154,8 +154,11 @@ exports.w_deny = function (next, connection, params) {
 
   // a deny colors the offending plugin's cell; it does not end the
   // connection, so leave local_port lit until the disconnect result arrives
+  const uuid = connection.transaction?.uuid ?? connection.uuid
+  if (!uuid) return next()
+
   const req = {
-    uuid: connection.transaction?.uuid ?? connection.uuid,
+    uuid,
     remote_host: display.get_remote_host(connection),
   }
 
@@ -163,7 +166,7 @@ exports.w_deny = function (next, connection, params) {
   const report_as = display.get_plugin_name(pi_name)
   if (req[report_as]) req[report_as].classy = bg_class
   if (!req[report_as]) req[report_as] = { classy: bg_class }
-  stick_severity(this, req.uuid, req)
+  stick_severity(this, uuid, req)
 
   wss.broadcast(req)
   next()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-watch",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Watch live SMTP traffic in a web interface",
   "main": "index.js",
   "files": [

--- a/test/watch.js
+++ b/test/watch.js
@@ -701,6 +701,18 @@ describe('watch', function () {
       assert.equal(sent.at(-1).access.classy, 'bg_dyellow')
     })
 
+    it('w_deny silently skips when connection has no uuid (outbound context)', async function () {
+      const sent = []
+      const plugin = makePlugin('watch', { register: false })
+      await initWss(plugin, sent)
+
+      const before = sent.length
+      await new Promise((resolve) =>
+        plugin.w_deny(resolve, { logdebug() {} }, [DENY, null, 'access', null, null, 'data']),
+      )
+      assert.equal(sent.length, before)
+    })
+
     it('queue_ok broadcasts queue success', async function () {
       const sent = []
       const plugin = makePlugin('watch', { register: false })


### PR DESCRIPTION
Seems the [previous](https://github.com/haraka/haraka-plugin-watch/pull/81) fix wasn't enough. Here is another attempt (thanks Claude).

Claude's analysis:

```
The only .replace() call is base_uuid at [index.js:22](vscode-webview://1qoupm73s384345hdubbql05mig36isgg2po81etfi3hvptn9tmc/index.js#L22), and it's reached from w_deny via stick_severity.

In w_deny ([index.js:159](vscode-webview://1qoupm73s384345hdubbql05mig36isgg2po81etfi3hvptn9tmc/index.js#L159)):

uuid: connection.transaction?.uuid ?? connection.uuid,
In the outbound context, connection is an outbound object (not an inbound Connection), so both connection.transaction?.uuid and connection.uuid resolve to undefined. That undefined is then passed to stick_severity → base_uuid(undefined) → crash.

The fix is to guard in w_deny — if there's no uuid, there's nothing meaningful to update.
```