### PR TITLE
fix(redis): prevent Redis pubsub connection drop from crashing Haraka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [2.2.4] - 2026-06-28
+
+- fix: prevent Redis pubsub connection drop from crashing Haraka
+
 ### [2.2.3] - 2026-06-16
 
 - fix: correctly handle deny when there is no uuid

--- a/index.js
+++ b/index.js
@@ -231,18 +231,39 @@ const phase_handlers = {
   },
 }
 
+exports.shutdown = function () {
+  if (this.pubsub?.isOpen) {
+    this.pubsub.quit().catch((err) => this.logerror(err.message))
+  }
+}
+
 exports.redis_subscribe_all_results = async function (next) {
   const plugin = this
 
-  if (this.pubsub) return // already subscribed?
+  if (this.pubsub?.isOpen) return next()
 
-  this.pubsub = redis.createClient(this.redisCfg.pubsub)
+  this.pubsub = redis.createClient({
+    ...this.redisCfg.pubsub,
+    socket: {
+      ...this.redisCfg.pubsub?.socket,
+      // retry indefinitely so a transient network drop never crashes Haraka
+      reconnectStrategy: (retries) => Math.min(retries * 100, 5000),
+    },
+  })
   this.pubsub.on('error', (err) => {
     this.logerror(err.message)
   })
-  await this.pubsub.connect()
 
-  await this.pubsub.pSubscribe('result-*', (message, channel) => {
+  try {
+    await this.pubsub.connect()
+  } catch (err) {
+    this.logerror(`pubsub connect failed: ${err.message}`)
+    this.pubsub = null
+    return next()
+  }
+
+  try {
+    await this.pubsub.pSubscribe('result-*', (message, channel) => {
     const match = /result-([A-F0-9\-.]+)$/.exec(channel) // uuid
     if (!match) {
       plugin.logerror('pattern: result-*')
@@ -276,8 +297,11 @@ exports.redis_subscribe_all_results = async function (next) {
 
     if (Object.keys(cells).length) wss.broadcast({ uuid, ...cells })
   })
+    this.logdebug(this, `pSubscribed to result-*`)
+  } catch (err) {
+    this.logerror(`pubsub pSubscribe failed: ${err.message}`)
+  }
 
-  this.logdebug(this, `pSubscribed to result-*`)
   next()
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-watch",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Watch live SMTP traffic in a web interface",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Attempt to fix:

```
2026-06-28 07:25:09.250698599  [ERROR] [-] [watch] Socket closed unexpectedly
2026-06-28 07:25:09.250700119  [ERROR] [A5C0C134-6BB6-4A01-8C27-DA5310BC46ED.1] [karma] Socket closed unexpectedly
2026-06-28 07:25:09.250701549  [ERROR] [D4EB954F-3D12-4EEC-B876-57884CCA9E6A.1] [karma] Socket closed unexpectedly
2026-06-28 07:25:09.250804105  [ERROR] [-] [watch] Socket closed unexpectedly
2026-06-28 07:25:09.251295624  [ERROR] [D7CF6F67-8A11-4ABA-AB9D-BFCDD59442EA] [karma] Socket closed unexpectedly
2026-06-28 07:25:09.251297614  [ERROR] [-] [watch] Socket closed unexpectedly
2026-06-28 07:25:09.252046938  [CRIT] [-] [core] Error: Socket closed unexpectedly
2026-06-28 07:25:09.252095730  [CRIT] [-] [core]     at Socket.<anonymous> (/path/to/Haraka/node_modules/@redis/client/dist/lib/client/socket.js:271:33)
2026-06-28 07:25:09.252147473  [CRIT] [-] [core]     at Object.onceWrapper (node:events:631:26)
2026-06-28 07:25:09.252149504  [CRIT] [-] [core]     at Socket.emit (node:events:509:28)
2026-06-28 07:25:09.252161594  [CRIT] [-] [core]     at TCP.<anonymous> (node:net:351:12)
2026-06-28 07:25:09.252568348  [NOTICE] [-] [core] Shutting down
2026-06-28 07:25:09.253437409  [ERROR] [9E8890C3-007D-45BD-B1CC-D5635D17B4BE.1] [karma] Socket closed unexpectedly
2026-06-28 07:25:09.253717995  [ERROR] [-] [watch] Socket closed unexpectedly
2026-06-28 07:25:09.254987029  [ERROR] [F286AA68-C19C-4B69-894F-F4021D303D8B.1] [karma] Socket closed unexpectedly
```

Claude's explanation:

**Problem**

When the TCP connection between Haraka and Redis drops unexpectedly (network blip, firewall idle-timeout, etc.), the watch plugin's pub/sub client (this.pubsub) loses its connection simultaneously with all other Redis clients. The other plugins (e.g. karma) recover gracefully because they use the shared client managed by haraka-plugin-redis, which has proper error handling and a reliable reconnectStrategy. The watch plugin creates its own separate redis.createClient() for pub/sub and relied on the default reconnectStrategy of whatever @redis/client version Haraka bundles — which in practice exhausted retries after ~3 seconds and allowed an unhandled error to propagate to Haraka core, causing a [CRIT] crash and full server restart.

Three secondary issues compounded this: the "already subscribed" guard returned without calling next() (risking an init hook stall), a failed initial connect() would throw unhandled (breaking startup when Redis is temporarily unreachable), and there was no shutdown hook to clean up this.pubsub on stop.

**Fix**

- Explicitly set reconnectStrategy to retry indefinitely (Math.min(retries * 100, 5000) ms), so a transient network drop is handled by @redis/client's built-in reconnect loop — which also automatically re-issues the pSubscribe after reconnection — instead of eventually crashing Haraka.
- Guard changed from if (this.pubsub) return to if (this.pubsub?.isOpen) return next(): always calls next(), and allows recreation if the client is in a closed state.
- Wrap connect() in try/catch so a failed initial connection is logged and continues rather than propagating unhandled.
- Wrap pSubscribe() in try/catch for the same reason.
- Add exports.shutdown to cleanly quit() the pubsub client on server stop.